### PR TITLE
fix: change prompt

### DIFF
--- a/kids-app/src/utils/conversation_config.js
+++ b/kids-app/src/utils/conversation_config.js
@@ -77,12 +77,11 @@ If the child says the [NG Words] or having [NG Words], please persude the child 
 Please don't persuade the child when the NG Words are not registered.
 
 ### example:
-1. 
-- Child: "I want to eat goldfish"
-- TeddyTalk: "Goldfish are yummy, aren’t they? But make sure to ask your parents before getting them!"
-
-2.
+1. if the NG Words is "goldfish"
 - Child: "What is this?"
-- TeddyTalk: "Let me see." "Oh, you are having [something]." But you have to ask your parents before getting them." "Who gave you that snack?"
+- TeddyTalk: "Let me see." "Oh, you are having Goldfish." But you have to ask your parents before getting them." "Who gave you that snack?"
 
+1. if "goldfish" is not included in the NG Words list
+- Child: "What is this?"
+- TeddyTalk: "Let me see." "Oh, you are having [goldfish]." "Who gave you that snack?"
 `

--- a/kids-app/src/utils/conversation_config.js
+++ b/kids-app/src/utils/conversation_config.js
@@ -72,8 +72,9 @@ Tool use: enabled.
    Child: "He said I can't play with his toys."
    TeddyTalk: "That's not nice at all. You should tell him that you can play with his toys when you want to."
 
-## NG Words:
-If the child says the following words, please persude the child not to do the activity.
+## NG Words rule:
+If the child says the [NG Words] or having [NG Words], please persude the child not to do the activity.
+Please don't persuade the child when the NG Words are not registered.
 
 ### example:
 1. 

--- a/parent-app/src/components/app-page.tsx
+++ b/parent-app/src/components/app-page.tsx
@@ -208,12 +208,16 @@ export function Page() {
   const fetchRecentActivities = async () => {
     const params = {
       TableName: CONVERSATION_TABLE_NAME,
-      Limit: 20,
-      ScanIndexForward: false,
+      KeyConditionExpression: "userId = :userId",
+      ExpressionAttributeValues: {
+        ":userId": "1", 
+      },
+      ScanIndexForward: false, 
+      Limit: 20
     };
-
+  
     try {
-      const result = await dynamoDb.scan(params).promise();
+      const result = await dynamoDb.query(params).promise();
       if (result.Items) {
         const activitiesWithSignedUrls = await Promise.all(
           result.Items.map(async (item) => {
@@ -229,11 +233,10 @@ export function Page() {
             return activity;
           })
         );
-        console.log("activitiesWithSignedUrls", activitiesWithSignedUrls);
         setActivities(activitiesWithSignedUrls);
       }
     } catch (error) {
-      console.error("Error fetching activities:", error);
+      console.error("Error fetching recent activities:", error);
     }
   };
 


### PR DESCRIPTION
This pull request includes updates to the conversation configuration in the kids app and improvements to the activity fetching logic in the parent app. The most important changes are detailed below:

### Kids App

* [`kids-app/src/utils/conversation_config.js`](diffhunk://#diff-31857f476ee1084bd41d074d69761b6021e398c7463c7f08ad2543b86cb2516cL75-R77): Updated the `NG Words` rule to clarify when to persuade the child not to do an activity.

### Parent App

* [`parent-app/src/components/app-page.tsx`](diffhunk://#diff-b2ce46c015e3cb1395938a85331d6ed383c6f2ce15706c7d4caa769d3c805765L211-R220): Changed the `fetchRecentActivities` function to use `query` instead of `scan` for better performance and added a condition to filter activities by `userId`.
* [`parent-app/src/components/app-page.tsx`](diffhunk://#diff-b2ce46c015e3cb1395938a85331d6ed383c6f2ce15706c7d4caa769d3c805765L232-R239): Removed a `console.log` statement and updated the error message to be more specific when fetching recent activities.