### PR TITLE
fix: fix the number of fetch activities

### DIFF
--- a/parent-app/src/components/app-page.tsx
+++ b/parent-app/src/components/app-page.tsx
@@ -243,7 +243,7 @@ export function Page() {
   const fetchDailyActivities = async () => {
     const params = {
       TableName: DAILY_SUMMARY_TABLE_NAME,
-      Limit: 5,
+      Limit: 100,
       ScanIndexForward: false,
     };
 


### PR DESCRIPTION
This pull request includes a change to the `parent-app/src/components/app-page.tsx` file to modify the limit of daily activities fetched.

* [`parent-app/src/components/app-page.tsx`](diffhunk://#diff-b2ce46c015e3cb1395938a85331d6ed383c6f2ce15706c7d4caa769d3c805765L246-R246): Increased the `Limit` parameter in the `fetchDailyActivities` function from 5 to 100.